### PR TITLE
Limit `model_max_length` to 2048 tokens for NeoX family models.

### DIFF
--- a/lib/chunkers.py
+++ b/lib/chunkers.py
@@ -80,6 +80,9 @@ class TextChunker:
 
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
+        if tokenizer.model_max_length > 2048:
+            print(f"WARNING: tokenizer model max length {tokenizer.model_max_length} is greater than 2048. ")
+            self.tokenizer.model_max_length = 2048
         self.input_chunker = LeftPadChunker(tokenizer.model_max_length, pad_with=tokenizer.eos_token_id)
         self.attention_chunker = LeftPadChunker(tokenizer.model_max_length, pad_with=0)
 


### PR DESCRIPTION
Bug in GPT-NeoX family tokenizers of models (including pythia) where `model_max_length` is `1000000000000000019884624838656` for some reason and causes an overflow error when trying to run `chunking.py`.

This PR caps the length to 2048 which is the sequence length the models were trained with.